### PR TITLE
feat: add from picture option to GPT modal

### DIFF
--- a/src/components/ModalUrlText.vue
+++ b/src/components/ModalUrlText.vue
@@ -39,6 +39,10 @@
                   class="w-full focus:ring-indigo-500 border text-black p-2 focus:border-indigo-500 shadow-sm sm:text-sm border-gray-300 rounded-md"
                 />
               </div>
+              <div class="flex items-center">
+                <Checkbox class="mr-2" v-model="localFromPicture" />
+                <div class="text-sm text-gray-600">{{ t('From picture') }}</div>
+              </div>
             </div>
             <div class="text-white text-center">
               <div
@@ -65,6 +69,7 @@
 <script lang="ts" setup>
 import { ref, watch, nextTick } from 'vue'
 import SInput from './Input.vue'
+import Checkbox from './Checkbox.vue'
 import { t } from '~src/i18n'
 
 const props = withDefaults(
@@ -77,6 +82,7 @@ const props = withDefaults(
     cancelText?: string
     url?: string
     text?: string
+    fromPicture?: boolean
   }>(),
   {
     placeholderUrl: 'https://example.com',
@@ -85,16 +91,18 @@ const props = withDefaults(
     cancelText: 'Cancel',
     url: '',
     text: '',
+    fromPicture: false,
   }
 )
 const emit = defineEmits<{
-  (e: 'confirm', v: { url: string; text: string }): void
+  (e: 'confirm', v: { url: string; text: string; fromPicture: boolean }): void
   (e: 'cancel'): void
   (e: 'update:modelValue', v: boolean): void
 }>()
 
 const localUrl = ref(props.url)
 const localText = ref(props.text)
+const localFromPicture = ref(props.fromPicture)
 const inputRef = ref<InstanceType<typeof SInput> | null>(null)
 const textareaRef = ref<HTMLTextAreaElement | null>(null)
 
@@ -104,6 +112,7 @@ watch(
     if (v) {
       localUrl.value = props.url || ''
       localText.value = props.text || ''
+      localFromPicture.value = props.fromPicture || false
       nextTick(() => {
         inputRef.value?.focus?.()
       })
@@ -112,7 +121,11 @@ watch(
 )
 
 function confirm() {
-  emit('confirm', { url: (localUrl.value || '').trim(), text: (localText.value || '').trim() })
+  emit('confirm', {
+    url: (localUrl.value || '').trim(),
+    text: (localText.value || '').trim(),
+    fromPicture: localFromPicture.value,
+  })
 }
 function close() {
   emit('cancel')

--- a/src/components/Storage.vue
+++ b/src/components/Storage.vue
@@ -35,6 +35,7 @@
       v-model="showImportUrlModal"
       :url="importUrl"
       :text="importText"
+      :fromPicture="importFromPicture"
       :title="t('JSON from URL')"
       :confirmText="t('Open GPT')"
       :placeholderUrl="t('https://example.com')"
@@ -156,6 +157,7 @@ let showImportUrlModal = ref(false)
 let showImportJsonModal = ref(false)
 let importUrl = ref('')
 let importText = ref('')
+let importFromPicture = ref(false)
 let importJsonText = ref('')
 let toastMessage = ref('')
 let toastTimer: number | null = null
@@ -245,15 +247,22 @@ function moveDown(index: number) {
 
 function openImportUrl() {
   importUrl.value = ''
+  importFromPicture.value = false
   showImportUrlModal.value = true
 }
 
-function confirmImportUrl(payload: { url: string; text: string }) {
+function confirmImportUrl(payload: { url: string; text: string; fromPicture: boolean }) {
   importUrl.value = payload.url
   importText.value = payload.text
+  importFromPicture.value = payload.fromPicture
   showImportUrlModal.value = false
   const locale = currentLocale.value === 'jp' ? 'Japanese' : 'English'
-  const prompt = buildImportRecipePrompt({ url: importUrl.value, text: importText.value, locale })
+  const prompt = buildImportRecipePrompt({
+    url: importUrl.value,
+    text: importText.value,
+    locale,
+    fromPicture: importFromPicture.value,
+  })
 
   const url = importUrl.value || ''
   if (url.includes('youtube.com')) {
@@ -306,6 +315,7 @@ function confirmImportJson(json: string) {
 function cancelImportUrl() {
   importUrl.value = ''
   importText.value = ''
+  importFromPicture.value = false
   showImportUrlModal.value = false
 }
 
@@ -385,6 +395,7 @@ function handleSharedFromQuery() {
   if (sharedUrl || combinedText) {
     importUrl.value = sharedUrl
     importText.value = combinedText
+    importFromPicture.value = false
     showImportUrlModal.value = true
   }
 }

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -45,6 +45,7 @@
   "Synced with file": "Synced with file",
   "Open GPT": "GPT",
   "Recipe text": "Recipe text",
+  "From picture": "From picture",
   "Paste JSON": "Paste JSON",
   "Import": "Import",
   "https://example.com": "https://example.com",

--- a/src/i18n/jp.json
+++ b/src/i18n/jp.json
@@ -45,6 +45,7 @@
   "Synced with file": "ファイルと同期しました",
   "Open GPT": "GPT",
   "Recipe text": "レシピ本文",
+  "From picture": "画像から",
   "Paste JSON": "JSONを貼り付け",
   "Import": "インポート",
   "https://example.com": "https://example.com",

--- a/src/services/prompt.ts
+++ b/src/services/prompt.ts
@@ -4,9 +4,9 @@
 export type LocaleText = 'English' | 'Japanese'
 
 export function buildImportRecipePrompt(
-  input: { url?: string; text?: string; locale: LocaleText }
+  input: { url?: string; text?: string; locale: LocaleText; fromPicture?: boolean }
 ): string {
-  const { url, text, locale } = input
+  const { url, text, locale, fromPicture } = input
   const unitRules = [
     'Allowed units (choose only from these and use these exact keys in ingredient.amountType): g, ml, tbl (tablespoon), tea (teaspoon), p (piece), pinch.',
   ].join(' ')
@@ -45,6 +45,10 @@ export function buildImportRecipePrompt(
     sourceInstruction = `Fetch the content of ${url} and also use the provided recipe text below. Combine and deduplicate details from both sources to produce a single clean, structured recipe JSON. If there is a conflict, prefer explicit amounts/units and mention assumptions in the note. Provided text:\n\n\`\`\`\n${safeText}\n\`\`\``
   } else {
     sourceInstruction = 'Convert the provided recipe into a clean, structured recipe JSON.'
+  }
+
+  if (fromPicture) {
+    sourceInstruction += ' Extract the recipe information from the attached pictures.'
   }
 
   return `${sourceInstruction} ${localeRule} Follow these strict rules: ${unitRules} ${ingredientRules} ${noteRules} The JSON must match this exact structure: ${jsonSchema} ${formattingRule}`


### PR DESCRIPTION
## Summary
- add "From picture" toggle to GPT import modal
- append prompt instruction to read recipe data from attached images when enabled
- localize new label in English and Japanese

## Testing
- `npm test` (fails: The environment variable CHROME_PATH must be set to executable of a build of Chromium)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68a1f1210afc8329ae292fe94e3d9241