### PR TITLE
fix: delay ChatGPT navigation until after prompt copy alert

### DIFF
--- a/src/components/Recipe.vue
+++ b/src/components/Recipe.vue
@@ -255,7 +255,10 @@ async function confirmAskGpt(question: string) {
       : 'English'
   const prompt = buildAskRecipePrompt(recipe.value, question, locale)
   const copied = await openChatGPT(prompt)
-  if (copied) alert(t('Prompt copied. Paste into ChatGPT.'))
+  if (copied) {
+    alert(t('Prompt copied. Paste into ChatGPT.'))
+    window.open('https://chatgpt.com/', '_blank')
+  }
 }
 
 function norm(type: string): string {

--- a/src/components/Storage.vue
+++ b/src/components/Storage.vue
@@ -273,7 +273,10 @@ async function confirmImportUrl(payload: { url: string; text: string; fromPictur
     window.open('https://gemini.google.com/', '_blank')
   } else {
     const copied = await openChatGPT(prompt)
-    if (copied) showToast(t('Prompt copied. Opening ChatGPT...'))
+    if (copied) {
+      showToast(t('Prompt copied. Opening ChatGPT...'))
+      window.open('https://chatgpt.com/', '_blank')
+    }
   }
 }
 

--- a/src/services/chatgpt.ts
+++ b/src/services/chatgpt.ts
@@ -31,6 +31,5 @@ export async function openChatGPT(prompt: string): Promise<boolean> {
   } catch (e) {
     legacyCopyToClipboard(prompt)
   }
-  window.open('https://chatgpt.com/', '_blank')
   return true
 }


### PR DESCRIPTION
## Summary
- show prompt copy alert before opening ChatGPT
- copy-only ChatGPT helper leaves navigation to caller
- ensure Storage prompt copies open ChatGPT after toast

## Testing
- `npm test` (fails: The environment variable CHROME_PATH must be set to executable of a build of Chromium version 54.0 or later.)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68a235fdec84832985bf0b167303c692