### PR TITLE
feat: include servings in import prompt

### DIFF
--- a/src/services/prompt.test.ts
+++ b/src/services/prompt.test.ts
@@ -36,3 +36,11 @@ describe('buildImportRecipePrompt source selection', () => {
   })
 })
 
+describe('buildImportRecipePrompt servings rule', () => {
+  it('asks for persons as first ingredient and sets original/desired', () => {
+    const p = buildImportRecipePrompt({ url: 'https://example.com/recipe', locale: L })
+    expect(p).to.contain('first ingredient named "Persons"')
+    expect(p).to.contain('original and desired')
+  })
+})
+

--- a/src/services/prompt.ts
+++ b/src/services/prompt.ts
@@ -11,6 +11,12 @@ export function buildImportRecipePrompt(
     'Allowed units (choose only from these and use these exact keys in ingredient.amountType): g, ml, tbl (tablespoon), tea (teaspoon), p (piece), pinch.',
   ].join(' ')
 
+  const servingsRule = [
+    'Determine the number of servings/persons from the source.',
+    'Insert it as the first ingredient named "Persons" with amount equal to that number and amountType "p".',
+    'Set both top-level original and desired to this value.',
+  ].join(' ')
+
   const ingredientRules = [
     `For each ingredient: remove any text in brackets/parentheses from the name (e.g., "Onion (chopped)" -> name: "Onion").`,
     `Move removed bracket details and any extra descriptors (e.g., "chopped", "to taste") into the ingredient.note field, in ${locale}.`,
@@ -52,7 +58,7 @@ export function buildImportRecipePrompt(
     sourceInstruction = 'Extract the recipe information from the attached pictures and convert it into a clean, structured recipe JSON.'
   }
 
-  return `${sourceInstruction} ${localeRule} Follow these strict rules: ${unitRules} ${ingredientRules} ${noteRules} The JSON must match this exact structure: ${jsonSchema} ${formattingRule}`
+  return `${sourceInstruction} ${localeRule} Follow these strict rules: ${unitRules} ${servingsRule} ${ingredientRules} ${noteRules} The JSON must match this exact structure: ${jsonSchema} ${formattingRule}`
 }
 
 export function buildAskRecipePrompt(recipe: any, question: string, locale: LocaleText): string {


### PR DESCRIPTION
## Summary
- ensure import prompt asks for servings as first ingredient "Persons" and sets original/desired accordingly
- cover new prompt rules with tests

## Testing
- `npm test` *(fails: The environment variable CHROME_PATH must be set to executable of a build of Chromium version 54.0 or later.)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68a2de9fbd98832994e4a777dd168734