### PR TITLE
fix: localize servings ingredient name

### DIFF
--- a/src/services/prompt.test.ts
+++ b/src/services/prompt.test.ts
@@ -37,10 +37,18 @@ describe('buildImportRecipePrompt source selection', () => {
 })
 
 describe('buildImportRecipePrompt servings rule', () => {
-  it('asks for persons as first ingredient and sets original/desired', () => {
-    const p = buildImportRecipePrompt({ url: 'https://example.com/recipe', locale: L })
-    expect(p).to.contain('first ingredient named "Persons"')
-    expect(p).to.contain('original and desired')
+  const locales: Record<LocaleText, string> = {
+    English: 'Servings',
+    German: 'Portionen',
+    Japanese: '人前',
+  }
+
+  Object.entries(locales).forEach(([locale, name]) => {
+    it(`uses "${name}" as the first ingredient for ${locale}`, () => {
+      const p = buildImportRecipePrompt({ url: 'https://example.com/recipe', locale: locale as LocaleText })
+      expect(p).to.contain(`first ingredient named "${name}"`)
+      expect(p).to.contain('original and desired')
+    })
   })
 })
 

--- a/src/services/prompt.ts
+++ b/src/services/prompt.ts
@@ -11,9 +11,17 @@ export function buildImportRecipePrompt(
     'Allowed units (choose only from these and use these exact keys in ingredient.amountType): g, ml, tbl (tablespoon), tea (teaspoon), p (piece), pinch.',
   ].join(' ')
 
+  const servingsNameMap = {
+    English: 'Servings',
+    German: 'Portionen',
+    Japanese: '人前',
+  } as const
+
+  const servingsName = servingsNameMap[locale]
+
   const servingsRule = [
     'Determine the number of servings/persons from the source.',
-    'Insert it as the first ingredient named "Persons" with amount equal to that number and amountType "p".',
+    `Insert it as the first ingredient named "${servingsName}" with amount equal to that number and amountType "p".`,
     'Set both top-level original and desired to this value.',
   ].join(' ')
 


### PR DESCRIPTION
## Summary
- localize the servings ingredient label in import prompt
- cover localization in tests

## Testing
- `npm test` *(fails: The environment variable CHROME_PATH must be set to executable of a build of Chromium version 54.0 or later.)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68a2e441aa1083298d06d5d9e36ad1e9