### PR TITLE
feat: show JSON import after GPT link

### DIFF
--- a/src/components/Storage.vue
+++ b/src/components/Storage.vue
@@ -153,6 +153,7 @@ import { mergeRecipesByExportedAt } from '~src/services/importExport'
 import { chooseExportFile, saveExportFile, loadFromFile } from '~src/services/fileExport'
 import { buildImportRecipePrompt } from '~src/services/prompt'
 import { openChatGPT } from '~src/services/chatgpt'
+import { handlePromptNoticeOk } from '~src/services/notice'
 
 const router = useRouter()
 const recipes = computed({ get: () => _recipes.value, set: (v) => (_recipes.value = v as any) })
@@ -461,8 +462,7 @@ function showAppNotice(title: string, message: string, icon?: string, okText?: s
 }
 
 function handleNoticeOk() {
-  const url = noticeOkUrl.value
-  if (url) window.open(url, '_blank')
+  handlePromptNoticeOk(noticeOkUrl.value, openImportJson)
 }
 
 onMounted(() => {

--- a/src/services/notice.test.ts
+++ b/src/services/notice.test.ts
@@ -1,0 +1,31 @@
+import { handlePromptNoticeOk } from './notice'
+import { expect } from 'chai'
+
+describe('handlePromptNoticeOk', () => {
+  it('opens URL and triggers import when URL provided', () => {
+    let opened: string | null = null
+    const orig = window.open
+    window.open = (u: string) => {
+      opened = u
+      return null as any
+    }
+    let called = false
+    handlePromptNoticeOk('https://chatgpt.com/', () => {
+      called = true
+    })
+    expect(opened).to.equal('https://chatgpt.com/')
+    expect(called).to.be.true
+    window.open = orig
+  })
+
+  it('does nothing without URL', () => {
+    let called = false
+    const orig = window.open
+    window.open = (() => null as any) as any
+    handlePromptNoticeOk(null, () => {
+      called = true
+    })
+    expect(called).to.be.false
+    window.open = orig
+  })
+})

--- a/src/services/notice.ts
+++ b/src/services/notice.ts
@@ -1,0 +1,6 @@
+export function handlePromptNoticeOk(url: string | null, openImportJson: () => void): void {
+  if (url) {
+    window.open(url, '_blank')
+    openImportJson()
+  }
+}


### PR DESCRIPTION
## Summary
- open JSON import modal after clicking ChatGPT/Gemini link
- add helper and tests for GPT notice handler

## Testing
- `npm test` *(fails: CHROME_PATH must be set)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68a2faf3e3248329b0fbc72a959a035a