### PR TITLE
feat: add toggle for ingredient notes

### DIFF
--- a/src/components/Recipe.vue
+++ b/src/components/Recipe.vue
@@ -98,7 +98,7 @@
                       style="font-size: 1.2rem;"
                       >{{ unitLabel(item.amountType as any) }}</span>
                   </template>
-                <div v-if="item.note" class="text-sm text-gray-400 mt-1">
+                <div v-if="item.note && (recipe.edit || showNotes)" class="text-sm text-gray-400 mt-1">
                   <b>{{ t('Note') }}:</b>
                   <span @click="() => clickNote(index)">{{ item.note }}</span>
                 </div>
@@ -167,6 +167,10 @@
           <p class="text-sm mt-3 px-2"><b>{{ t('Note') }}:</b></p>
           <div class="markdown text-sm px-2" v-html="markedRender"></div>
         </template>
+        <div v-if="!recipe.edit" class="text-sm mt-3 px-2 flex items-center">
+          <Checkbox v-model="showNotes" />
+          <span class="ml-2">{{ t('Show ingredient notes') }}</span>
+        </div>
       </div>
     </div>
       <Footer />
@@ -210,6 +214,7 @@ import { normalizeAmountType } from '~src/services/units'
 
 const route = useRoute()
 const router = useRouter()
+const showNotes = ref(true)
 
 const recipeId = computed(() => {
   return +(route.params.id as any)

--- a/src/i18n/de.json
+++ b/src/i18n/de.json
@@ -9,6 +9,7 @@
   "View mode": "Ansichtsmodus",
   "Edit mode": "Bearbeitungsmodus",
   "Checklist": "Checkliste",
+  "Show ingredient notes": "Zutatennotizen anzeigen",
   "Open recipe web page": "Rezept-Webseite öffnen",
   "Original": "Original",
   "Original amount": "Ursprüngliche Menge",

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -9,6 +9,7 @@
   "View mode": "View mode",
   "Edit mode": "Edit mode",
   "Checklist": "Checklist",
+  "Show ingredient notes": "Show ingredient notes",
   "Open recipe web page": "Open recipe web page",
   "Original": "Original",
   "Original amount": "Original amount",

--- a/src/i18n/jp.json
+++ b/src/i18n/jp.json
@@ -9,6 +9,7 @@
   "View mode": "表示モード",
   "Edit mode": "編集モード",
   "Checklist": "チェックリスト",
+  "Show ingredient notes": "材料のノートを表示",
   "Open recipe web page": "レシピのウェブページを開く",
   "Original": "オリジナル",
   "Original amount": "必要量",


### PR DESCRIPTION
## Summary
- add checkbox to toggle ingredient notes visibility in recipe overview
- localize checkbox label in English, German, and Japanese

## Testing
- `npm test` *(fails: The environment variable CHROME_PATH must be set to executable of a build of Chromium version 54.0 or later.)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68a300484a148329aa224edb1805158f