### PR TITLE
fix: refocus json textarea after returning from GPT

### DIFF
--- a/src/components/ModalInput.vue
+++ b/src/components/ModalInput.vue
@@ -57,7 +57,7 @@
 </template>
 
 <script lang="ts" setup>
-import { ref, watch, nextTick } from 'vue'
+import { ref, watch, nextTick, onMounted, onUnmounted } from 'vue'
 import SInput from './Input.vue'
 import { t } from '~src/i18n'
 
@@ -88,6 +88,27 @@ const emit = defineEmits<{
 const localValue = ref(props.value)
 const inputRef = ref<InstanceType<typeof SInput> | null>(null)
 const textareaRef = ref<HTMLTextAreaElement | null>(null)
+function refocusTextarea() {
+  const el = textareaRef.value
+  if (!el) return
+  el.blur()
+  window.setTimeout(() => {
+    el.focus()
+  }, 200)
+}
+function handleVisibility() {
+  if (document.visibilityState === 'visible' && props.modelValue && props.multiline) {
+    refocusTextarea()
+  }
+}
+onMounted(() => {
+  document.addEventListener('visibilitychange', handleVisibility)
+  window.addEventListener('focus', handleVisibility)
+})
+onUnmounted(() => {
+  document.removeEventListener('visibilitychange', handleVisibility)
+  window.removeEventListener('focus', handleVisibility)
+})
 watch(
   () => props.modelValue,
   (v) => {


### PR DESCRIPTION
## Summary
- ensure import JSON textarea reopens smartphone keyboard by blurring and refocusing when page becomes visible again

## Testing
- `npm test` *(fails: CHROME_PATH must be set to executable of a Chromium build)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68a35acdd2d88329914602f77c9ab3d8