### PR TITLE
style: tone down overview edit button

### DIFF
--- a/src/components/Storage.vue
+++ b/src/components/Storage.vue
@@ -108,9 +108,10 @@
               </Button>
             </template>
             <template v-else>
-              <Button color="gray" :tone="400" @click="() => initRename(index)">
-                <Icon icon="fal fa-pen" size="1.2rem" />
-              </Button>
+              <i
+                @click="() => initRename(index)"
+                class="text-sm cursor-pointer fal fa-pen p-2 text-gray-600"
+              />
             </template>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- make overview item edit button a plain dark gray icon without background

## Testing
- `npm test` *(fails: CHROME_PATH not set)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68a361d349d483299e9dba91da7eef61