### PR TITLE
style: adjust overview colors and trash icon

### DIFF
--- a/src/components/Storage.vue
+++ b/src/components/Storage.vue
@@ -80,7 +80,7 @@
         :style="transitionName === 'ov' ? staggerStyle(index) : null"
         class="ov-item"
       >
-        <div v-if="item.rename" class="flex items-baseline rounded-xl bg-pink-400 px-2 py-2 my-1">
+        <div v-if="item.rename" class="flex items-baseline rounded-xl bg-pink-600 text-white px-2 py-2 my-1">
           <div class="flex-grow pr-2">
             <SInput
               @enter="() => rename(index)"
@@ -90,11 +90,12 @@
             />
           </div>
           <div class="flex-grow whitespace-nowrap text-right">
-            <i @click="moveDown(index)" class="text-sm cursor-pointer fal fa-arrow-down p-2 text-pink-600" />
-            <i @click="moveUp(index)" class="text-sm cursor-pointer fal fa-arrow-up p-2 text-pink-600 mr-2" />
-            <Button color="red" class="mr-1" :tone="300" @click="() => initRemove(index, item.name)">
-              <Icon icon="fal fa-trash-alt" size="1.2rem" />
-            </Button>
+            <i @click="moveDown(index)" class="text-sm cursor-pointer fal fa-arrow-down p-2 text-white" />
+            <i @click="moveUp(index)" class="text-sm cursor-pointer fal fa-arrow-up p-2 text-white mr-2" />
+            <i
+              @click="() => initRemove(index, item.name)"
+              class="text-sm cursor-pointer fal fa-trash-alt p-2 mr-1"
+            />
             <Button color="green" :tone="400" @click="() => rename(index)">
               <Icon icon="fal fa-check" size="1.2rem" />
             </Button>
@@ -102,7 +103,7 @@
         </div>
         <div
           v-else
-          class="flex items-center rounded-xl bg-pink-400 px-2 py-2 my-1 overflow-x-auto md:overflow-visible no-scrollbar"
+          class="flex items-center rounded-xl bg-pink-600 text-white px-2 py-2 my-1 overflow-x-auto md:overflow-visible no-scrollbar"
         >
           <div
             class="flex items-baseline w-full flex-shrink-0 pr-2 md:w-auto md:flex-1 md:flex-shrink"
@@ -113,17 +114,18 @@
             >
               {{ item.name }}
             </div>
-            <i class="fal fa-angle-right text-pink-500 ml-2 flex-none" />
+            <i class="fal fa-angle-right text-white ml-2 flex-none" />
           </div>
           <div class="flex items-center flex-none pl-4">
-            <i @click="moveDown(index)" class="text-sm cursor-pointer fal fa-arrow-down p-2 text-pink-600" />
-            <i @click="moveUp(index)" class="text-sm cursor-pointer fal fa-arrow-up p-2 text-pink-600 mr-2" />
-            <Button color="red" class="mr-1" :tone="300" @click="() => initRemove(index, item.name)">
-              <Icon icon="fal fa-trash-alt" size="1.2rem" />
-            </Button>
+            <i @click="moveDown(index)" class="text-sm cursor-pointer fal fa-arrow-down p-2 text-white" />
+            <i @click="moveUp(index)" class="text-sm cursor-pointer fal fa-arrow-up p-2 text-white mr-2" />
+            <i
+              @click="() => initRemove(index, item.name)"
+              class="text-sm cursor-pointer fal fa-trash-alt p-2 mr-1"
+            />
             <i
               @click="() => initRename(index)"
-              class="text-sm cursor-pointer fal fa-pen p-2 text-pink-600"
+              class="text-sm cursor-pointer fal fa-pen p-2 text-white"
             />
           </div>
         </div>


### PR DESCRIPTION
## Summary
- use pink-600 background with white text for overview entries
- replace trash button with plain icon to remove background

## Testing
- `npm test` *(fails: The environment variable CHROME_PATH must be set to executable of a build of Chromium version 54.0 or later.)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68a4cb6e15088329b47b469eaa6587cd