### PR TITLE
fix: preserve scroll position when reordering

### DIFF
--- a/src/components/Storage.vue
+++ b/src/components/Storage.vue
@@ -75,7 +75,7 @@
     <TransitionGroup :name="transitionName" tag="div" class="flex-grow" appear>
       <div
         v-for="(item, index) in recipes"
-        :key="index"
+        :key="item.id"
         v-show="filterMatch(item?.name)"
         :style="transitionName === 'ov' ? staggerStyle(index) : null"
         class="ov-item"

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -1,6 +1,15 @@
 import { ref, Ref, watch } from 'vue'
 import { migrateRecipeUnits, normalizeAmountType } from '~src/services/units'
 
+export function uuidv4() {
+  return ([1e7] as any + -1e3 + -4e3 + -8e3 + -1e11).replace(
+    /[018]/g,
+    (c: any) => (
+      c ^ (crypto.getRandomValues(new Uint8Array(1))[0] & (15 >> (c / 4)))
+    ).toString(16)
+  )
+}
+
 export type Ingredient = {
   name: string
   amount: number | string
@@ -55,6 +64,13 @@ export function updateRecipesToStore(value: Recipe[]) {
   localStorage.setItem('recipes', stringified)
 }
 
+storedRecipes.forEach((r) => {
+  if (!r.id) {
+    r.id = uuidv4()
+  }
+})
+updateRecipesToStore(storedRecipes)
+
 export const storedOpenedRecipe = JSON.parse(
   localStorage.getItem('openedRecipe') || '-1'
 )
@@ -64,14 +80,5 @@ watch(openedRecipe, (val) => {
 })
 
 export const routeState = ref<Record<string, any>>({})
-
-export function uuidv4() {
-  return ([1e7] as any + -1e3 + -4e3 + -8e3 + -1e11).replace(
-    /[018]/g,
-    (c: any) => (
-      c ^ (crypto.getRandomValues(new Uint8Array(1))[0] & (15 >> (c / 4)))
-    ).toString(16)
-  )
-}
 
 // no-op


### PR DESCRIPTION
## Summary
- ensure recipes have stable ids persisted on load
- use recipe ids as keys so horizontal scroll stays with items when moved

## Testing
- `npm test` *(fails: The environment variable CHROME_PATH must be set to executable of a build of Chromium version 54.0 or later.)*
- `npm run lint` *(fails: Cannot find package 'prettier-plugin-svelte' imported from /workspace/kukkingu/noop.js)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68a4ceff1af08329bc2bcfa7468cf5d7