### PR TITLE
feat: improve shopping list details

### DIFF
--- a/src/services/planner.ts
+++ b/src/services/planner.ts
@@ -35,22 +35,35 @@ export function generateShoppingList(plan: WeeklyPlan): ShoppingListItem[] {
         const multiplier = recipePlan.servings / recipeServings
 
         recipe.ingredients.forEach(ingredient => {
-
           const key = `${ingredient.name.toLowerCase()}-${ingredient.amountType}`
+          const parsedAmount = typeof ingredient.amount === 'number'
+            ? ingredient.amount
+            : parseFloat(ingredient.amount as string) || 0
+          const amountToAdd = parsedAmount * multiplier
+          const trimmedNote = typeof ingredient.note === 'string' ? ingredient.note.trim() : ''
 
           if (ingredientMap.has(key)) {
             const existing = ingredientMap.get(key)!
-            existing.amount += (typeof ingredient.amount === 'number' ? ingredient.amount : parseFloat(ingredient.amount as string) || 0) * multiplier
+            existing.amount += amountToAdd
             if (!existing.recipes.includes(recipe.id!)) {
               existing.recipes.push(recipe.id!)
+            }
+            if (trimmedNote) {
+              if (!existing.notes) {
+                existing.notes = []
+              }
+              if (!existing.notes.includes(trimmedNote)) {
+                existing.notes.push(trimmedNote)
+              }
             }
           } else {
             ingredientMap.set(key, {
               name: ingredient.name,
-              amount: (typeof ingredient.amount === 'number' ? ingredient.amount : parseFloat(ingredient.amount as string) || 0) * multiplier,
+              amount: amountToAdd,
               amountType: ingredient.amountType,
               checked: false,
-              recipes: [recipe.id!]
+              recipes: [recipe.id!],
+              notes: trimmedNote ? [trimmedNote] : []
             })
           }
         })

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -59,6 +59,7 @@ export type ShoppingListItem = {
   amountType: string
   checked?: boolean
   recipes: string[] // recipe IDs that use this ingredient
+  notes?: string[]
 }
 
 // Initialize recipes from IndexedDB


### PR DESCRIPTION
## Summary
- aggregate ingredient notes into shopping list items and render them under each usage entry
- add a notes toggle beside the dense view control and round displayed amounts up to whole numbers
- insert a blank line between the shopping list share header and its bullet list

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68cda58f406c8329b3fc3d835564edf4