### PR TITLE
fix: retain recipe route after reload

### DIFF
--- a/src/components/Recipe.vue
+++ b/src/components/Recipe.vue
@@ -381,11 +381,11 @@
   </template>
 
 <script lang="ts" setup>
-import { computed, ref, watch, nextTick } from 'vue'
+import { computed, ref, watch, watchEffect, nextTick } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import * as marked from 'marked'
 import Footer from '~components/Footer.vue'
-import { recipes as _recipes, globalSearchFilter, recipeViewSettings } from '~src/store/index'
+import { recipes as _recipes, globalSearchFilter, recipeViewSettings, recipesInitialized } from '~src/store/index'
 import Button from './Button.vue'
 import SInput from './Input.vue'
 import Icon from './Icon.vue'
@@ -443,9 +443,12 @@ const recipe = computed<any>({
   },
 })
 
-if (!_recipes.value || _recipes.value.length === 0) {
-  router.push('/')
-}
+watchEffect(() => {
+  if (!recipesInitialized.value) return
+  if (!recipe.value) {
+    router.replace('/')
+  }
+})
 
 // Ensure view mode when opening a recipe: if currently in edit mode, switch to view
 watch(

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -70,6 +70,7 @@ export type ShoppingListItem = {
 
 // Initialize recipes from IndexedDB
 export const recipes: Ref<Recipe[]> = ref([])
+export const recipesInitialized = ref(false)
 
 // Load recipes from IndexedDB on initialization, but wait for migration first
 async function initializeRecipes() {
@@ -104,6 +105,8 @@ async function initializeRecipes() {
     console.error('Failed to load recipes from IndexedDB:', error)
     // Fallback to empty array
     recipes.value = []
+  } finally {
+    recipesInitialized.value = true
   }
 }
 


### PR DESCRIPTION
## Summary
- add a store flag to expose when recipes have finished loading
- wait for recipe data initialization in the recipe view before redirecting back to storage

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68d18f69c574832991440df69c967dbe